### PR TITLE
Parse SGE cpu syntax

### DIFF
--- a/prepare_run.py
+++ b/prepare_run.py
@@ -86,7 +86,9 @@ def write_qsiprep_command():
         #     cmd += ['--acquisition_type', acquisition_type]
         # If on HPC, get the cores/memory limits
         if config.get('sge-cpu'):
-            cmd += ['--n_cpus', str(max(1, int(config.get('sge-cpu'))-1))]
+            # Parse SGE cpu syntax, such as "4-8" or just "4"
+            cpuMin = int(config.get('sge-cpu').split('-')[0])
+            cmd += ['--n_cpus', str(max(1, cpuMin - 1))]
         if config.get('combine_all_dwis', False):
             cmd.append('--combine_all_dwis')
         if config.get('denoise_before_combining', False):


### PR DESCRIPTION
In SGE, you can ask for a range of CPUs, such as `4-8`.

This patch just checks for a dash character, and removes it before trying to turn the value into an integer. If you asked for `4-8` and got 5, you'd parse it as `4`. To take advantage of the 5 you were assigned, you'd have to know how many CPUs SGE actually assigned you, which I don't know how to do offhand. This just fixes the possible launch-time parse error.

This patch is dry-coded, but seems to check out:

```
$ python3
Python 3.6.8 (default, Oct  7 2019, 12:59:55) 

>>> cpus = '4-8'
>>> cpuMin = int(cpus.split('-')[0])
>>> str(max(1, cpuMin))
'4'

>>> cpus = '4'
>>> cpuMin = int(cpus.split('-')[0])
>>> str(max(1, cpuMin))
'4'
```